### PR TITLE
Utilise option pour paramètre telDir

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R: c(
   )
 Description: A package primarily intended for Insee staff members willing to use R in order to exploit and analyse data produced by the institute. This package makes it possible to either download on-the-fly the date from the website, or load pre-processed data. It also provides a (so far non comprehensive) list of datasets available on the website.
 Depends: R (>= 3.5.0)
-Imports: readr, readxl, stringi, rappdirs, httr, apinsee, jsonlite
+Imports: readr, readxl, stringi, httr, apinsee, jsonlite
 Suggests: tidyverse, data.table, testthat, RCurl, httpuv
 Remotes: rlesur/apinsee
 License: MIT + file LICENSE

--- a/R/telechargerDonnees.R
+++ b/R/telechargerDonnees.R
@@ -1,8 +1,7 @@
 #' Téléchargement des données sur le site de l'Insee
 #'
+#' @inheritParams telechargerFichier
 #' @param donnees le nom des données que l'on souhaite télécharger sur le site de l'Insee, que l'on peut retrouver dans la table [liste_donnees]
-#' @param date optionnel : le millésime des données si nécessaire. Peut prendre le format YYYY ou encore DD/MM/YYYY ; dans le dernier cas, on prendra le premier jour de la période de référence.
-#' @param telDir optionnel : le dossier dans lequel sont téléchargées les données brutes. Par défaut, un dossier temporaire de cache.
 #' @param argsApi optionnel : dans le cas où c'est une API REST qui est utilisée, il est possible de spécifier des paramètres spécifiques à cette API de manière à collecter l'information désirée.
 #' @param vars optionnel : un vecteur pour spécifier les variables à importer. Utile pour les données massives difficiles à charger en mémoire, voir @details .
 #' @param ... paramètres additionnels relatifs à l'importation des données
@@ -20,6 +19,6 @@
 #' }
 #' @importFrom utils download.file unzip read.csv tail
 #' @export
-telechargerDonnees <- function(donnees, date=NULL, telDir=NULL, argsApi=NULL, vars=NULL, ...) {
+telechargerDonnees <- function(donnees, date=NULL, telDir=getOption("doremifasol.telDir"), argsApi=NULL, vars=NULL, ...) {
   return(chargerDonnees(telechargerFichier(donnees, date, telDir, argsApi), vars, ...))
 }

--- a/R/telechargerFichier.R
+++ b/R/telechargerFichier.R
@@ -2,7 +2,7 @@
 #'
 #' @param donnees le nom des données que l'on souhaite télécharger sur le site de l'Insee, que l'on peut retrouver dans la table ([liste_donnees])
 #' @param date optionnel : le millésime des données si nécessaire. Peut prendre le format YYYY ou encore DD/MM/YYYY ; dans le dernier cas, on prendra le premier jour de la période de référence.
-#' @param telDir optionnel : le dossier dans lequel sont téléchargées les données brutes. Par défaut, un dossier temporaire de cache.
+#' @param telDir optionnel : le dossier dans lequel sont téléchargées les données brutes. Par défaut, la valeur définie par `options(doremifasol.telDir = ...)`. Si l'utilisateur n'a pas défini cette valeur au préalable, un dossier temporaire de cache.
 #' @param argsApi optionnel : dans le cas où c'est une API REST qui est utilisée, il est possible de spécifier des paramètres spécifiques à cette API de manière à collecter l'information désirée. Cf. [@details ].
 #' 
 #' @details 
@@ -18,7 +18,7 @@
 #' }
 #' @importFrom utils download.file unzip read.csv tail
 #' @export
-telechargerFichier <- function(donnees, date=NULL, telDir=NULL, argsApi=NULL) {
+telechargerFichier <- function(donnees, date=NULL, telDir=getOption("doremifasol.telDir"), argsApi=NULL) {
   ## check the parameter donnees takes a valid value
   if (!donnees %in% ld$nom)
     stop("Le param\u00e8tre donnees est mal sp\u00e9cifi\u00e9, la valeur n'est pas r\u00e9f\u00e9renc\u00e9e")
@@ -37,7 +37,7 @@ telechargerFichier <- function(donnees, date=NULL, telDir=NULL, argsApi=NULL) {
   #dossier de téléchargement # si NULL aller dans le cache
   cache <- FALSE
   if (is.null(telDir)) {
-    telDir <- ifelse(.Platform$OS.type == "windows", tempdir(), rappdirs::user_cache_dir())
+    telDir <- tempdir()
     cache <- TRUE
   } else {
     if (!dir.exists(telDir))

--- a/man/telechargerDonnees.Rd
+++ b/man/telechargerDonnees.Rd
@@ -7,7 +7,7 @@
 telechargerDonnees(
   donnees,
   date = NULL,
-  telDir = NULL,
+  telDir = getOption("doremifasol.telDir"),
   argsApi = NULL,
   vars = NULL,
   ...
@@ -18,7 +18,7 @@ telechargerDonnees(
 
 \item{date}{optionnel : le millésime des données si nécessaire. Peut prendre le format YYYY ou encore DD/MM/YYYY ; dans le dernier cas, on prendra le premier jour de la période de référence.}
 
-\item{telDir}{optionnel : le dossier dans lequel sont téléchargées les données brutes. Par défaut, un dossier temporaire de cache.}
+\item{telDir}{optionnel : le dossier dans lequel sont téléchargées les données brutes. Par défaut, la valeur définie par `options(doremifasol.telDir = ...)`. Si l'utilisateur n'a pas défini cette valeur au préalable, un dossier temporaire de cache.}
 
 \item{argsApi}{optionnel : dans le cas où c'est une API REST qui est utilisée, il est possible de spécifier des paramètres spécifiques à cette API de manière à collecter l'information désirée.}
 

--- a/man/telechargerFichier.Rd
+++ b/man/telechargerFichier.Rd
@@ -4,14 +4,19 @@
 \alias{telechargerFichier}
 \title{Téléchargement des données sur le site de l'Insee}
 \usage{
-telechargerFichier(donnees, date = NULL, telDir = NULL, argsApi = NULL)
+telechargerFichier(
+  donnees,
+  date = NULL,
+  telDir = getOption("doremifasol.telDir"),
+  argsApi = NULL
+)
 }
 \arguments{
 \item{donnees}{le nom des données que l'on souhaite télécharger sur le site de l'Insee, que l'on peut retrouver dans la table ([liste_donnees])}
 
 \item{date}{optionnel : le millésime des données si nécessaire. Peut prendre le format YYYY ou encore DD/MM/YYYY ; dans le dernier cas, on prendra le premier jour de la période de référence.}
 
-\item{telDir}{optionnel : le dossier dans lequel sont téléchargées les données brutes. Par défaut, un dossier temporaire de cache.}
+\item{telDir}{optionnel : le dossier dans lequel sont téléchargées les données brutes. Par défaut, la valeur définie par `options(doremifasol.telDir = ...)`. Si l'utilisateur n'a pas défini cette valeur au préalable, un dossier temporaire de cache.}
 
 \item{argsApi}{optionnel : dans le cas où c'est une API REST qui est utilisée, il est possible de spécifier des paramètres spécifiques à cette API de manière à collecter l'information désirée. Cf. [@details ].}
 }


### PR DESCRIPTION
Modifs suite à la discussion dans l'issue #16.

J'ai supprimé la dépendance à rappdirs. Je crois que ce n'était plus nécessaire, mais pas sûr à 100%.

(au passage, j'ai aussi utilisé `@inheritParams` pour les paramètres ayant la même description pour les 2 fonctions)