### PR TITLE
supprime fichiers décompressés

### DIFF
--- a/R/chargerDonnnees.R
+++ b/R/chargerDonnnees.R
@@ -14,6 +14,7 @@
 #' dl_bpe <- telechargerFichier(donnees = "BPE_ENS")
 #' bpe <- chargerDonnees(dl_bpe)}
 chargerDonnees <- function(telechargementFichier, vars = NULL, ...) {
+
   ## check download has worked
   if (is.null(telechargementFichier$result))
     stop("Le t\u00e9l\u00e9chargement a rencontr\u00e9 un probl\u00e8me.")
@@ -59,8 +60,6 @@ chargerDonnees <- function(telechargementFichier, vars = NULL, ...) {
       telechargementFichier$argsImport[["col_types"]] <- colsOnly
     }
     res <- as.data.frame(do.call(readr::read_delim, c(telechargementFichier$argsImport, ...))) 
-    # supprime fichiers décompressés
-    if (telechargementFichier$zip) unlink(unzipped)
   } else if (telechargementFichier$type == "xls") {
     if (!is.null(telechargementFichier$argsImport$sheet)) {
       res <- as.data.frame(do.call(readxl::read_xls, c(telechargementFichier$argsImport, ...)))
@@ -94,7 +93,12 @@ chargerDonnees <- function(telechargementFichier, vars = NULL, ...) {
       warning("Il n'est pas possible de filtrer les variables charg\u00e9es en m\u00e9moire sur le format JSON pour le moment.")
     res <- do.call(chargerDonneesJson, telechargementFichier$argsImport)
   } else stop("Type de fichier inconnu")
+  
+  # supprime fichiers décompressés
+  if (telechargementFichier$zip) unlink(unzipped)
+
   return(res)
+
 }
 
 chargerDonneesJson <- function(fichier, nom = c("SIRENE_SIREN", "SIRENE_SIRET")) {

--- a/R/chargerDonnnees.R
+++ b/R/chargerDonnnees.R
@@ -21,14 +21,16 @@ chargerDonnees <- function(telechargementFichier, vars = NULL, ...) {
   ## unzip if necessary
   if (telechargementFichier$zip) {
     nomFichier <- telechargementFichier$fileArchive
+    dossier_unz <- dirname(nomFichier)
     if (!endsWith(nomFichier, ".zip")) {
       stop("Le fichier t\u00e9l\u00e9charg\u00e9 n'est pas une archive zip.")
     } else {
       if (!telechargementFichier$big_zip) {
-        unzip(nomFichier, exdir = dirname(nomFichier))
+        unzipped <- unzip(nomFichier, exdir = dossier_unz)
       } else {
-        unz <- tryCatch(unzip(nomFichier, exdir = dirname(nomFichier), unzip = "unzip"))
-        if (!is.null(unz)) stop(unz$message)
+        unzipped <- file.path(dossier_unz, unzip(nomFichier, list = TRUE)$Name)
+        err_unz <- tryCatch(unzip(nomFichier, exdir = dossier_unz, unzip = "unzip"))
+        if (!is.null(err_unz)) stop(err_unz$message)
       }
     }
     ## check the dl file exists
@@ -57,6 +59,8 @@ chargerDonnees <- function(telechargementFichier, vars = NULL, ...) {
       telechargementFichier$argsImport[["col_types"]] <- colsOnly
     }
     res <- as.data.frame(do.call(readr::read_delim, c(telechargementFichier$argsImport, ...))) 
+    # supprime fichiers décompressés
+    if (telechargementFichier$zip) unlink(unzipped)
   } else if (telechargementFichier$type == "xls") {
     if (!is.null(telechargementFichier$argsImport$sheet)) {
       res <- as.data.frame(do.call(readxl::read_xls, c(telechargementFichier$argsImport, ...)))


### PR DESCRIPTION
Parce que :
- cela encombre le disque de l'utilisateur (avec des données redondantes par rapport au zip) ;
- cela ne prend pas beaucoup de temps de décompresser une archive (même un "big_zip").