### PR TITLE
Ajout URL page insee.fr 

### DIFF
--- a/R/consulter.R
+++ b/R/consulter.R
@@ -2,33 +2,33 @@
 #'
 #' @inheritParams telechargerFichier
 #' @param donnees le nom des données dont on veut consulter la page sur le site de l'Insee. La description complète des données associées à ce nom figure dans la table ([liste_donnees]).
-#' @param consultation Booléen qui indique si on veut consulter directement consulter la page sur son navigateur (TRUE) ou seulement récupérer l'URL de la page (FALSE).
+#' @param url_only `TRUE` pour seulement récupérer l'URL de la page sans ouvrir le navigateur.
 #'
-#' @return La fonction ouvre le lien dans le navigateur. Elle retourne accessoirement le lien vers la page web, de manière invisible.
+#' @return Par défaut, la fonction ouvre le lien dans le navigateur. Elle retourne accessoirement le lien vers la page web, de manière invisible.
 #'
 #' @export
 #'
 #' @examples
 #' consulter(donnees = "BPE_ENS")
 #' consulter("RP_LOGEMENT", date = "2016")
-#' # Pour récupérer seulement l'URL de la page
-#' consulter("RP_LOGEMENT", date = "2016", consultation = FALSE)
+#' # Pour seulement obtenir l'URL de la page
+#' consulter("RP_LOGEMENT", date = "2016", url_only = TRUE)
 
-consulter <- function(donnees, date = NULL, consultation = TRUE) {
+consulter <- function(donnees, date = NULL, url_only = FALSE) {
 
-  caract <- infosDonnees(donnees, date, consultation)
+  caract <- infosDonnees(donnees, date, silencieux = url_only)
 
   # construit l'url web à partir de l'url du fichier
   url <- sub("fichier/([0-9]+)/.+$", "\\1", caract$lien)
   if (caract$collection == "GEOGRAPHIE") {
     url <- sub("/statistiques/", "/information/", url)
   }
-  
-  if (isTRUE(consultation)) {
-    # ouvre dans navigateur
-    utils::browseURL(url)
-  } 
-  
+
+  if (url_only) return(url)
+
+  # ouvre dans navigateur
+  utils::browseURL(url)
+
   invisible(url)
 
 }

--- a/R/consulter.R
+++ b/R/consulter.R
@@ -11,6 +11,8 @@
 #' @examples
 #' consulter(donnees = "BPE_ENS")
 #' consulter("RP_LOGEMENT", date = "2016")
+#' # Pour récupérer seulement l'URL de la page
+#' consulter("RP_LOGEMENT", date = "2016", consultation = FALSE)
 
 consulter <- function(donnees, date = NULL, consultation = TRUE) {
 

--- a/R/consulter.R
+++ b/R/consulter.R
@@ -2,6 +2,7 @@
 #'
 #' @inheritParams telechargerFichier
 #' @param donnees le nom des données dont on veut consulter la page sur le site de l'Insee. La description complète des données associées à ce nom figure dans la table ([liste_donnees]).
+#' @param consultation Booléen qui indique si on veut consulter directement consulter la page sur son navigateur (TRUE) ou seulement récupérer l'URL de la page (FALSE).
 #'
 #' @return La fonction ouvre le lien dans le navigateur. Elle retourne accessoirement le lien vers la page web, de manière invisible.
 #'
@@ -11,9 +12,9 @@
 #' consulter(donnees = "BPE_ENS")
 #' consulter("RP_LOGEMENT", date = "2016")
 
-consulter <- function(donnees, date = NULL) {
+consulter <- function(donnees, date = NULL, consultation = TRUE) {
 
-  caract <- infosDonnees(donnees, date)
+  caract <- infosDonnees(donnees, date, consultation)
 
   # construit l'url web à partir de l'url du fichier
   url <- sub("fichier/([0-9]+)/.+$", "\\1", caract$lien)
@@ -21,8 +22,10 @@ consulter <- function(donnees, date = NULL) {
     url <- sub("/statistiques/", "/information/", url)
   }
   
-  # ouvre dans navigateur
-  utils::browseURL(url)
+  if (isTRUE(consultation)) {
+    # ouvre dans navigateur
+    utils::browseURL(url)
+  } 
   
   invisible(url)
 

--- a/R/donnees_dispo.R
+++ b/R/donnees_dispo.R
@@ -37,6 +37,15 @@ donnees_dispo <- function(recherche_init = NULL,
   # 1 - construit table à afficher
   affich <- listToDf(liste = ld, vars = c("collection", "libelle", "nom", "date_ref", "size"))
   affich$size <- round(as.numeric(affich$size) / 1048576, 1) # conversion Mo
+  # Ajout url page
+  affich$page <- sapply(affich$nom,
+                        consulter,
+                        date=ifelse(
+                          is.na(substr(liste_donnees$date_ref,1,4)),
+                          "dernier",
+                          substr(liste_donnees$date_ref,1,4)),
+                        consultation = FALSE)
+  affich$page <- paste0("<a target='_blank' rel='noopener noreferrer' href='",affich$page,"'>","Consulter la page associée","</a>")
   affich <- affich[order(affich$collection, -rank(affich$date_ref), affich$nom), ]
 
   # 2 - paramètres additionnels pour DT::datatable
@@ -49,8 +58,9 @@ donnees_dispo <- function(recherche_init = NULL,
   params$data     <- affich
   params$rownames <- FALSE
   params$colnames <- c("Collection", "Description", "Nom court",
-                       "Date de r\u00e9f\u00e9rence", "Taille (Mo)")
+                       "Date de r\u00e9f\u00e9rence", "Taille (Mo)" , "Lien sur Insee.fr")
   params$extensions <- c("Buttons")
+  params$escape <- FALSE
 
   # 2.2 - paramètres modifiables,
   #       mais avec valeurs défaut différentes de celles de DT::data.table

--- a/R/utile.R
+++ b/R/utile.R
@@ -12,13 +12,13 @@
 #' l'année doit être spécifiée.
 #'
 #' @inheritParams telechargerFichier
-#' @param consultation Booléen qui indique si on veut consulter directement consulter la page sur son navigateur (TRUE) ou seulement récupérer l'URL de la page (FALSE).
+#' @param silencieux mettre à `TRUE` pour ne pas afficher les messages.
 #'
 #' @return Une unique ligne de `liste_donnees` (sous forme de list).
 #' 
 #' @keywords internal
 
-infosDonnees <- function(donnees, date = NULL, consultation = TRUE) {
+infosDonnees <- function(donnees, date = NULL, silencieux = FALSE) {
   
   donnees <- toupper(donnees) # pour rendre insensible à la casse
   liste_nom <- vapply(ld, `[[`, "nom", FUN.VALUE = character(1))
@@ -46,7 +46,7 @@ infosDonnees <- function(donnees, date = NULL, consultation = TRUE) {
 
   if (!is.null(date) && tolower(date) == "dernier") {
     date <- sort(possible, decreasing = TRUE)[1]
-    if (isTRUE(consultation)) {
+    if (!silencieux) {
       message(
         "S\u00e9lection automatique des donn\u00e9es les plus r\u00e9centes ",
         "(date = ", date, ")."

--- a/R/utile.R
+++ b/R/utile.R
@@ -12,12 +12,13 @@
 #' l'année doit être spécifiée.
 #'
 #' @inheritParams telechargerFichier
+#' @param consultation Booléen qui indique si on veut consulter directement consulter la page sur son navigateur (TRUE) ou seulement récupérer l'URL de la page (FALSE).
 #'
 #' @return Une unique ligne de `liste_donnees` (sous forme de list).
 #' 
 #' @keywords internal
 
-infosDonnees <- function(donnees, date = NULL) {
+infosDonnees <- function(donnees, date = NULL, consultation = TRUE) {
   
   donnees <- toupper(donnees) # pour rendre insensible à la casse
   liste_nom <- vapply(ld, `[[`, "nom", FUN.VALUE = character(1))
@@ -45,10 +46,12 @@ infosDonnees <- function(donnees, date = NULL) {
 
   if (!is.null(date) && tolower(date) == "dernier") {
     date <- sort(possible, decreasing = TRUE)[1]
-    message(
-      "S\u00e9lection automatique des donn\u00e9es les plus r\u00e9centes ",
-      "(date = ", date, ")."
-    )
+    if (isTRUE(consultation)) {
+      message(
+        "S\u00e9lection automatique des donn\u00e9es les plus r\u00e9centes ",
+        "(date = ", date, ")."
+      )
+    }
   }
 
   select <- 1

--- a/man/consulter.Rd
+++ b/man/consulter.Rd
@@ -4,15 +4,17 @@
 \alias{consulter}
 \title{Consulter le descriptif des données sur insee.fr}
 \usage{
-consulter(donnees, date = NULL)
+consulter(donnees, date = NULL, url_only = FALSE)
 }
 \arguments{
 \item{donnees}{le nom des données dont on veut consulter la page sur le site de l'Insee. La description complète des données associées à ce nom figure dans la table (\link{liste_donnees}).}
 
 \item{date}{optionnel : le millésime des données si nécessaire. Peut prendre le format YYYY ou encore DD/MM/YYYY ; dans le dernier cas, on prendra le premier jour de la période de référence. Spécifier \code{"dernier"} sélectionne automatiquement le millésime le plus récent.}
+
+\item{url_only}{\code{TRUE} pour seulement récupérer l'URL de la page sans ouvrir le navigateur.}
 }
 \value{
-La fonction ouvre le lien dans le navigateur. Elle retourne accessoirement le lien vers la page web, de manière invisible.
+Par défaut, la fonction ouvre le lien dans le navigateur. Elle retourne accessoirement le lien vers la page web, de manière invisible.
 }
 \description{
 Consulter le descriptif des données sur insee.fr
@@ -20,4 +22,6 @@ Consulter le descriptif des données sur insee.fr
 \examples{
 consulter(donnees = "BPE_ENS")
 consulter("RP_LOGEMENT", date = "2016")
+# Pour seulement obtenir l'URL de la page
+consulter("RP_LOGEMENT", date = "2016", url_only = TRUE)
 }

--- a/man/infosDonnees.Rd
+++ b/man/infosDonnees.Rd
@@ -4,12 +4,14 @@
 \alias{infosDonnees}
 \title{Recherche ligne d'informations dans liste_donnees}
 \usage{
-infosDonnees(donnees, date = NULL)
+infosDonnees(donnees, date = NULL, silencieux = FALSE)
 }
 \arguments{
 \item{donnees}{le nom court des données que l'on souhaite télécharger sur le site de l'Insee. La description complète des données associés à ce nom figure dans la table \code{\link{liste_donnees}}. Insensible à la casse.}
 
 \item{date}{optionnel : le millésime des données si nécessaire. Peut prendre le format YYYY ou encore DD/MM/YYYY ; dans le dernier cas, on prendra le premier jour de la période de référence. Spécifier \code{"dernier"} sélectionne automatiquement le millésime le plus récent.}
+
+\item{silencieux}{mettre à \code{TRUE} pour ne pas afficher les messages.}
 }
 \value{
 Une unique ligne de \code{liste_donnees} (sous forme de list).


### PR DESCRIPTION
Bon je tente une PR pour ajouter les liens vers les pages d'Insee.fr dans `donnees_dispo()`.   
cf. cette discussion #71
Je ne suis pas sûr d'avoir adopté la meilleure stratégie dans les modifications du package mais ça marche au final donc je vous laisse voir si ça vous demande beaucoup de corrections ou pas  

Les principales modifications apportées :  
- Ajout d'une colonne dans la data.frame en sortie de `donnees_dispo()`. Son contenu utilise `consulter()`
- Ajout d'un argument `consultation` (booléen) dans `consulter()` (pour éviter d'avoir le navigateur qui s'affole pour chaque appel à `consulter()`
- même chose dans `infoDonnees()` pour éviter d'avoir le message "Sélection automatique des données les plus récentes" qui s'affiche systématiquement
- Ajout de `params$escape <- FALSE` dans les paramètres du datatable pour un bon affichage des URLs
